### PR TITLE
Update helper.php for preserving UPPER / lower case in column names

### DIFF
--- a/syntax/entry.php
+++ b/syntax/entry.php
@@ -135,16 +135,6 @@ class syntax_plugin_data_entry extends DokuWiki_Syntax_Plugin {
     function _showData($data, &$R){
         global $ID;
         $ret = '';
-        
-        $crumbs = array_reverse(breadcrumbs());
-        $i = 0;
-        foreach($crumbs as $id => $name) {
-          if ( $i == 1 ) { break; }
-          $i++;
-        }
-        $meta = p_get_metadata( $id );
-        $ret .= '<p style=" margin: 1em; border: thin outset; padding: 0.5em; font-weight: bold; font-style: italic; ">'.html_wikilink(':'.$id,'⇐ zurück zu: '.$meta['title']).'</p>';
-
 
         if (method_exists($R, 'startSectionEdit')) {
             $data['classes'] .= ' ' . $R->startSectionEdit($data['pos'], 'plugin_data');


### PR DESCRIPTION
# IMPORTANT: ONLY the "Update helper.php" is meant here - sorry, due to not carefully thinking automatic blew up that request erroneously with things that have to do nothing with pull requesting ...
# What: Skipped utf8_strtolower() for 'key' in function _column()
# Why: Preserve UPPER / lower case in column names when editing dataentry with the built-in custom entry editor
# Note: Seems that utf8_strtolower() is used here to avoid trouble with allowed characters in SQLite column names?
