### PR TITLE
Casting from string to real type for right filtering and sorting

### DIFF
--- a/syntax/table.php
+++ b/syntax/table.php
@@ -583,7 +583,7 @@ class syntax_plugin_data_table extends DokuWiki_Syntax_Plugin {
                                   " '".$filter['value']."'"; //value is already escaped
                       }else{
                         $where2 .= ' '.$filter['logic'].' '.$table.'.value '.$filter['compare'].
-                                  " cast(".$filter['value']." as real)"; //value is already escaped
+                                  " cast(".$filter['value']." as real)"; //value is cast as real type
                       }
                     }
                 }


### PR DESCRIPTION
SQLite treats data as string type. Therefore, filters containing numbers as conditions like "data <= 10" haven't worked to find matching entries. Moreover, sorting of columns in datatable has been shown in strange order. (This issue is similar to http://stackoverflow.com/questions/18796923/why-is-sqlite-treating-a-number-as-a-string) 

This pull request contains two fixes.
- When a value for a filter is numeric, it is cast as real type in SQL query.
- When a name of column contains '-val', the column is sorted in numerical order.
