### PR TITLE
Possibility for hidden type aliases

### DIFF
--- a/admin/aliases.php
+++ b/admin/aliases.php
@@ -99,7 +99,7 @@ class admin_plugin_data_aliases extends DokuWiki_Admin_Plugin {
 
             $form->addElement('<td>');
             $form->addElement(form_makeMenuField('d['.$cur.'][type]',
-                                array('','page','title','mail','url', 'dt', 'wiki','tag'),
+                                array('','page','title','mail','url', 'dt', 'wiki','tag','hidden'),
                               $row['type'],''));
             $form->addElement('</td>');
 


### PR DESCRIPTION
After modification if you add for example the parameter '_hide', custom type 'hidden' to the name of the data field, this field will not be shown on the wiki page. But if you edit the data with the custom entry editor, the parameter will be visible.
Furtheron it is possible to define a list of possible values for this hidden data type.
