### PR TITLE
Make default image width configurable

### DIFF
--- a/conf/default.php
+++ b/conf/default.php
@@ -3,3 +3,4 @@
 $conf['edit_content_only'] = 0;
 $conf['use_dataresolve'] = 1;
 $conf['rownumbers'] = 0;
+$conf['image_width'] = 40;

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -3,3 +3,4 @@
 $meta['edit_content_only'] = array('onoff');
 $meta['use_dataresolve'] = array('onoff');;
 $meta['rownumbers'] = array('onoff');
+$meta['image_width'] = array('string');

--- a/helper.php
+++ b/helper.php
@@ -319,7 +319,7 @@ class helper_plugin_data extends DokuWiki_Plugin {
                     if(substr($type, 0, 3) == 'img') {
                         $width = (int) substr($type, 3);
                         if(!$width) {
-                            $width = 40;
+                            $width = $this->getConf('image_width');
                         }
 
                         list($mediaid, $title) = explode('|', $val, 2);

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,3 +5,4 @@ $lang['edit_content_only'] = 'Edit only the content of a data entry, not the str
 // https://github.com/splitbrain/dokuwiki-plugin-data/commit/8a16166886238906c21c7babc44bccf49c7f50a1
 $lang['use_dataresolve'] = 'Use DATARESOLVE calls for LIKE statements';
 $lang['rownumbers'] = 'Enable "rownumbers" by default in all tables';
+$lang['image_width'] = 'Default width for images';


### PR DESCRIPTION
It is difficult to change the image width in a data entry. Although it's possible to use `img<num>` in the column name, that `<num>` value will get lost when using the custom entry editor.
That's a bug by itself. But even without that bug it makes sense to be able to change the default dimensions of images in general.