### PR TITLE
Fix handling of single title fields w/o title

### DIFF
--- a/_test/syntax_plugin_data_entry.test.php
+++ b/_test/syntax_plugin_data_entry.test.php
@@ -65,6 +65,38 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $this->assertEquals($cols, $result['cols'], 'Cols array corrupted');
     }
 
+    function test_titleEntry_noTitle() {
+        $test_entry = '---- dataentry ----
+        test_title: bar
+        ----';
+        $plugin = new syntax_plugin_data_entry();
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_entry, 0, 10, $handler);
+        $renderer = new Doku_Renderer_xhtml();
+        $plugin->render('xhtml',$renderer,$data);
+        $result = $renderer->doc;
+        $result = substr($result,0,strpos($result,'</a>')+4);
+        $result = substr($result,strpos($result,'<a'));
+        $this->assertSame('<a href="/./doku.php?id=bar" class="wikilink2" title="bar" rel="nofollow">bar</a>',$result);
+    }
+
+    function test_titleEntry_withTitle() {
+        $test_entry = '---- dataentry ----
+        test_title: link:to:page|TitleOfPage
+        ----';
+        $plugin = new syntax_plugin_data_entry();
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_entry, 0, 10, $handler);
+        $renderer = new Doku_Renderer_xhtml();
+        $plugin->render('xhtml',$renderer,$data);
+        $result = $renderer->doc;
+        $result = substr($result,0,strpos($result,'</a>')+4);
+        $result = substr($result,strpos($result,'<a'));
+        $this->assertSame('<a href="/./doku.php?id=link:to:page" class="wikilink2" title="link:to:page" rel="nofollow">TitleOfPage</a>',$result);
+    }
+
     function test_editToWiki() {
         $data = array(
             'classes' => 'projects',

--- a/helper.php
+++ b/helper.php
@@ -241,7 +241,9 @@ class helper_plugin_data extends DokuWiki_Plugin {
                     //use ID from first value of the multivalued line
                     if($title == null) {
                         $title = $id;
-                        $id = $storedID;
+                        if(!empty($storedID)) {
+                            $id = $storedID;
+                        }
                     } else {
                         $storedID = $id;
                     }


### PR DESCRIPTION
This hopefully also fixes issues #150 and affects possibly selfthinker/dokuwiki_plugin_orgchart#1

However the link text doesn't yet appear to be what it used to be and it possibly needs more tests covering the type "pageid" since it is affected and "multivalued lines" as they are mentioned in the comment for ``$storedID``.