### PR TITLE
Restructure page and title types

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -143,6 +143,9 @@ class helper_plugin_data extends DokuWiki_Plugin {
 
                 return trim($email . ' ' . $name);
             case 'page':
+                list($id, $title) = explode('|', $value, 2);
+                $id = cleanID($id);
+                return $id . " | " . $title;
             case 'nspage':
                 return cleanID($value);
             default:
@@ -230,11 +233,12 @@ class helper_plugin_data extends DokuWiki_Plugin {
                 $type = $type['type'];
             }
             switch($type) {
-                case 'page':
-                    $val = $this->_addPrePostFixes($column['type'], $val);
-                    $outs[] = $R->internallink($val, null, null, true);
-                    break;
                 case 'title':
+                    list($id, $title) = explode('|', $val, 2);
+                    $val = $this->_addPrePostFixes($column['type'], $id);
+                    $outs[] = $R->internallink($val, $title, null, true);
+                    break;
+                case 'page':
                 case 'pageid':
                     list($id, $title) = explode('|', $val, 2);
 


### PR DESCRIPTION
The types page and pageid are now handled similar, but pageid is not
cleaned. If page and pageid are provided without title then the id is
shown as title. If they are provided with a title, then this title is
shown.
If a title field is not provided with a title, then the shown title depends on
the useheadings setting. If it has a title, then the title is shown.