### PR TITLE
Title fields use headings

### DIFF
--- a/_test/db.test.php
+++ b/_test/db.test.php
@@ -1,0 +1,119 @@
+<?php
+
+
+/**
+ * @group plugin_data
+ * @group plugins
+ * @group slow
+ */
+class db_data_entry_test extends DokuWikiTest {
+
+    protected $pluginsEnabled = array('data', 'sqlite',);
+
+    public static function setUpBeforeClass() {
+        parent::setUpBeforeClass();
+    }
+
+
+    public function setUp() {
+        parent::setUp();
+
+        saveWikiText('foo',"====== Page-Heading ======",'summary');
+        $req = new TestRequest();
+        $req->get(array(),'/doku.php?id=foo');
+
+
+        saveWikiText('testpage',"---- dataentry Testentry ----\n"
+                               . "test1_title: foo|bar\n"
+                               . "----\n",'summary');
+        //trigger save to db
+        $req = new TestRequest();
+        $req->get(array(),'/doku.php?id=testpage');
+    }
+
+    function test_title_input_id () {
+
+        $test_table = "---- datatable Testtable ----\n"
+        . "cols: %pageid%, test1\n"
+        . "filter: test1~ *foo*\n";
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_table');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_table, 0, 0, $handler);
+        $renderer = new Doku_Renderer_xhtml();
+        $plugin->render('xhtml',$renderer,$data);
+
+        $result = $renderer->doc;
+
+        $actual_value = substr($result,strpos($result,'<td class="align test1">')+24);
+        $actual_value = substr($actual_value,0,strpos($actual_value,'</td>'));
+        $expected_value = 'foo|bar';
+        $this->assertSame($expected_value,$actual_value);
+
+        $actual_link = substr($result,strpos($result,'<td class="align pageid">')+25);
+        $actual_link = substr($actual_link,strpos($actual_link,'doku.php'));
+        $actual_link = substr($actual_link,0,strpos($actual_link,'</a>'));
+
+        $this->assertSame('doku.php?id=testpage" class="wikilink1" title="testpage">testpage',$actual_link);
+
+    }
+
+    function test_title_input_title () {
+
+        $test_table = "---- datatable Testtable ----\n"
+            . "cols: %pageid%, test1\n"
+            . "filter: test1~ *bar*\n";
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_table');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_table, 0, 0, $handler);
+        $renderer = new Doku_Renderer_xhtml();
+        $plugin->render('xhtml',$renderer,$data);
+
+        $result = $renderer->doc;
+
+        $actual_value = substr($result,strpos($result,'<td class="align test1">')+24);
+        $actual_value = substr($actual_value,0,strpos($actual_value,'</td>'));
+        $expected_value = 'foo|bar';
+        $this->assertSame($expected_value,$actual_value);
+
+        $actual_link = substr($result,strpos($result,'<td class="align pageid">')+25);
+        $actual_link = substr($actual_link,strpos($actual_link,'doku.php'));
+        $actual_link = substr($actual_link,0,strpos($actual_link,'</a>'));
+
+        $this->assertSame('doku.php?id=testpage" class="wikilink1" title="testpage">testpage',$actual_link);
+    }
+
+    function test_title_input_Heading () {
+
+        $test_table = "---- datatable Testtable ----\n"
+            . "cols: %pageid%, test1\n"
+            . "filter: test1_title~ *Heading*\n";
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_table');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_table, 0, 0, $handler);
+        $renderer = new Doku_Renderer_xhtml();
+        $plugin->render('xhtml',$renderer,$data);
+
+        $result = $renderer->doc;
+
+        $actual_value = substr($result,strpos($result,'<td class="align test1">')+24);
+        $actual_value = substr($actual_value,0,strpos($actual_value,'</td>'));
+        $expected_value = 'foo|bar';
+        $this->assertSame($expected_value,$actual_value);
+
+        $actual_link = substr($result,strpos($result,'<td class="align pageid">')+25);
+        $actual_link = substr($actual_link,strpos($actual_link,'doku.php'));
+        $actual_link = substr($actual_link,0,strpos($actual_link,'</a>'));
+
+        $this->assertSame('doku.php?id=testpage" class="wikilink1" title="testpage">testpage',$actual_link);
+    }
+
+}

--- a/_test/db.test.php
+++ b/_test/db.test.php
@@ -116,4 +116,34 @@ class db_data_entry_test extends DokuWikiTest {
         $this->assertSame('doku.php?id=testpage" class="wikilink1" title="testpage">testpage',$actual_link);
     }
 
+    function test_title_input_stackns () {
+
+        $test_table = "---- datatable Testtable ----\n"
+            . "cols: %pageid%, test1\n";
+
+        global $ID;
+        $ID = 'foo:bar:start';
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_table');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_table, 0, 0, $handler);
+        $renderer = new Doku_Renderer_xhtml();
+        $plugin->render('xhtml',$renderer,$data);
+
+        $result = $renderer->doc;
+
+        $actual_value = substr($result,strpos($result,'<td class="align test1">')+24);
+        $actual_value = substr($actual_value,0,strpos($actual_value,'</td>'));
+        $expected_value = 'foo|bar';
+        $this->assertSame($expected_value,$actual_value);
+
+        $actual_link = substr($result,strpos($result,'<td class="align pageid">')+25);
+        $actual_link = substr($actual_link,strpos($actual_link,'doku.php'));
+        $actual_link = substr($actual_link,0,strpos($actual_link,'</a>'));
+
+        $this->assertSame('doku.php?id=testpage" class="wikilink1" title="testpage">testpage',$actual_link);
+    }
+
 }

--- a/_test/helper.test.php
+++ b/_test/helper.test.php
@@ -136,10 +136,10 @@ class helper_plugin_data_test extends DokuWikiTest {
         $this->assertEquals('value1, value2, val',
             $helper->_formatData(array('type' => ''), "value1\n value2\n val", $renderer));
 
-        $this->assertEquals('link: page ',
+        $this->assertEquals('link: :page ',
             $helper->_formatData(array('type' => 'page'), "page", $renderer));
 
-        $this->assertEquals('link: page title',
+        $this->assertEquals('link: :page title',
             $helper->_formatData(array('type' => 'title'), "page|title", $renderer));
 
         $this->assertEquals('link: page title',

--- a/_test/syntax_plugin_data_entry.test.php
+++ b/_test/syntax_plugin_data_entry.test.php
@@ -2,6 +2,20 @@
 
 require_once DOKU_INC . 'inc/parser/xhtml.php';
 
+class Doku_Renderer_xhtml_mock extends Doku_Renderer_xhtml {
+
+    function internallink($id, $name = null, $search = null, $returnonly = false, $linktype = 'content') {
+        $inputvalues = array(
+            'id' => $id,
+            'name' => $name,
+            'search' => $search,
+            'returnonly' => $returnonly,
+            'linktype' => $linktype
+        );
+        return "<internallink>" . serialize($inputvalues) . "</internallink>";
+    }
+}
+
 /**
  * @group plugin_data
  * @group plugins
@@ -11,6 +25,10 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
     protected $pluginsEnabled = array('data', 'sqlite');
 
     private $exampleEntry;
+
+    public function setUp() {
+        parent::setUp();
+    }
 
     function __construct() {
         $this->exampleEntry = "---- dataentry projects ----\n"
@@ -65,36 +83,131 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $this->assertEquals($cols, $result['cols'], 'Cols array corrupted');
     }
 
-    function test_titleEntry_noTitle() {
+    function test_pageEntry_noTitle() {
         $test_entry = '---- dataentry ----
-        test_title: bar
+        test1_page: foo
         ----';
-        $plugin = new syntax_plugin_data_entry();
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_entry');
 
         $handler = new Doku_Handler();
         $data = $plugin->handle($test_entry, 0, 10, $handler);
-        $renderer = new Doku_Renderer_xhtml();
+        $renderer = new Doku_Renderer_xhtml_mock();
         $plugin->render('xhtml',$renderer,$data);
         $result = $renderer->doc;
-        $result = substr($result,0,strpos($result,'</a>')+4);
-        $result = substr($result,strpos($result,'<a'));
-        $this->assertSame('<a href="/./doku.php?id=bar" class="wikilink2" title="bar" rel="nofollow">bar</a>',$result);
+        $result = substr($result,0,strpos($result,'</internallink>'));
+        $result = substr($result,strpos($result,'<internallink>')+14);
+        $result = unserialize($result);
+
+        $this->assertSame('foo',$result['id']);
+        $this->assertSame(null,$result['name'], 'page does not accept a title. useheading decides');
     }
+
+    function test_pageEntry_withTitle() {
+        $test_entry = '---- dataentry ----
+        test1_page: foo|bar
+        ----';
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_entry');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_entry, 0, 10, $handler);
+        $renderer = new Doku_Renderer_xhtml_mock();
+        $plugin->render('xhtml',$renderer,$data);
+        $result = $renderer->doc;
+        $result = substr($result,0,strpos($result,'</internallink>'));
+        $result = substr($result,strpos($result,'<internallink>')+14);
+        $result = unserialize($result);
+
+        $this->assertSame('foo_bar',$result['id'], 'for type page a title becomes part of the id');
+        $this->assertSame(null,$result['name'], 'page never accepts a title. useheading decides');
+    }
+
+    function test_pageidEntry_noTitle() {
+        $test_entry = '---- dataentry ----
+        test1_pageid: foo
+        ----';
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_entry');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_entry, 0, 10, $handler);
+        $renderer = new Doku_Renderer_xhtml_mock();
+        $plugin->render('xhtml',$renderer,$data);
+        $result = $renderer->doc;
+        $result = substr($result,0,strpos($result,'</internallink>'));
+        $result = substr($result,strpos($result,'<internallink>')+14);
+        $result = unserialize($result);
+
+        $this->assertSame('foo',$result['id']);
+        $this->assertSame('foo',$result['name'], 'pageid: use the pageid as title if no title is provided.');
+    }
+
+    function test_pageidEntry_withTitle() {
+        $test_entry = '---- dataentry ----
+        test1_pageid: foo|bar
+        ----';
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_entry');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_entry, 0, 10, $handler);
+        $renderer = new Doku_Renderer_xhtml_mock();
+        $plugin->render('xhtml',$renderer,$data);
+        $result = $renderer->doc;
+        $result = substr($result,0,strpos($result,'</internallink>'));
+        $result = substr($result,strpos($result,'<internallink>')+14);
+        $result = unserialize($result);
+
+        $this->assertSame('foo',$result['id'], "wrong id handed to internal link");
+        $this->assertSame('bar',$result['name'], 'pageid: use the provided title');
+    }
+
+    function test_titleEntry_noTitle() {
+        $test_entry = '---- dataentry ----
+        test1_title: foo
+        ----';
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_entry');
+
+        $handler = new Doku_Handler();
+        $data = $plugin->handle($test_entry, 0, 10, $handler);
+        $renderer = new Doku_Renderer_xhtml_mock();
+        $plugin->render('xhtml',$renderer,$data);
+        $result = $renderer->doc;
+        $result = substr($result,0,strpos($result,'</internallink>'));
+        $result = substr($result,strpos($result,'<internallink>')+14);
+        $result = unserialize($result);
+
+        $this->assertSame('foo',$result['id']);
+        $this->assertSame(null,$result['name'], 'no title should be given to internal link. Let useheading decide.');
+    }
+
 
     function test_titleEntry_withTitle() {
         $test_entry = '---- dataentry ----
-        test_title: link:to:page|TitleOfPage
+        test3_title: link:to:page|TitleOfPage
         ----';
-        $plugin = new syntax_plugin_data_entry();
+
+        /** @var syntax_plugin_data_entry $plugin */
+        $plugin = plugin_load('syntax','data_entry');
 
         $handler = new Doku_Handler();
         $data = $plugin->handle($test_entry, 0, 10, $handler);
-        $renderer = new Doku_Renderer_xhtml();
+        $renderer = new Doku_Renderer_xhtml_mock();
         $plugin->render('xhtml',$renderer,$data);
         $result = $renderer->doc;
-        $result = substr($result,0,strpos($result,'</a>')+4);
-        $result = substr($result,strpos($result,'<a'));
-        $this->assertSame('<a href="/./doku.php?id=link:to:page" class="wikilink2" title="link:to:page" rel="nofollow">TitleOfPage</a>',$result);
+        $result = substr($result,0,strpos($result,'</internallink>'));
+        $result = substr($result,strpos($result,'<internallink>')+14);
+        $result = unserialize($result);
+        
+        $this->assertSame('link:to:page',$result['id']);
+        $this->assertSame('TitleOfPage',$result['name'], 'The Title provided should be the title shown.');
     }
 
     function test_editToWiki() {

--- a/_test/syntax_plugin_data_entry.test.php
+++ b/_test/syntax_plugin_data_entry.test.php
@@ -100,7 +100,7 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $result = substr($result,strpos($result,'<internallink>')+14);
         $result = unserialize($result);
 
-        $this->assertSame('foo',$result['id']);
+        $this->assertSame(':foo',$result['id']);
         $this->assertSame(null,$result['name'], 'page does not accept a title. useheading decides');
     }
 
@@ -121,7 +121,7 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $result = substr($result,strpos($result,'<internallink>')+14);
         $result = unserialize($result);
 
-        $this->assertSame('foo_bar',$result['id'], 'for type page a title becomes part of the id');
+        $this->assertSame(':foo_bar',$result['id'], 'for type page a title becomes part of the id');
         $this->assertSame(null,$result['name'], 'page never accepts a title. useheading decides');
     }
 
@@ -184,7 +184,7 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $result = substr($result,strpos($result,'<internallink>')+14);
         $result = unserialize($result);
 
-        $this->assertSame('foo',$result['id']);
+        $this->assertSame(':foo',$result['id']);
         $this->assertSame(null,$result['name'], 'no title should be given to internal link. Let useheading decide.');
     }
 
@@ -206,7 +206,7 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $result = substr($result,strpos($result,'<internallink>')+14);
         $result = unserialize($result);
 
-        $this->assertSame('link:to:page',$result['id']);
+        $this->assertSame(':link:to:page',$result['id']);
         $this->assertSame('TitleOfPage',$result['name'], 'The Title provided should be the title shown.');
     }
 

--- a/_test/syntax_plugin_data_entry.test.php
+++ b/_test/syntax_plugin_data_entry.test.php
@@ -205,7 +205,7 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $result = substr($result,0,strpos($result,'</internallink>'));
         $result = substr($result,strpos($result,'<internallink>')+14);
         $result = unserialize($result);
-        
+
         $this->assertSame('link:to:page',$result['id']);
         $this->assertSame('TitleOfPage',$result['name'], 'The Title provided should be the title shown.');
     }

--- a/helper.php
+++ b/helper.php
@@ -205,6 +205,13 @@ class helper_plugin_data extends DokuWiki_Plugin {
         return $value;
     }
 
+    public function ensureAbsoluteId($id) {
+        if (substr($id,0,1) !== ':') {
+            $id = ':' . $id;
+        }
+        return $id;
+    }
+
     /**
      * Return XHTML formated data, depending on column type
      *
@@ -232,11 +239,13 @@ class helper_plugin_data extends DokuWiki_Plugin {
             switch($type) {
                 case 'page':
                     $val = $this->_addPrePostFixes($column['type'], $val);
+                    $val = $this->ensureAbsoluteId($val);
                     $outs[] = $R->internallink($val, null, null, true);
                     break;
                 case 'title':
                     list($id, $title) = explode('|', $val, 2);
                     $id = $this->_addPrePostFixes($column['type'], $id);
+                    $id = $this->ensureAbsoluteId($id);
                     $outs[] = $R->internallink($id, $title, null, true);
                     break;
                 case 'pageid':
@@ -253,6 +262,7 @@ class helper_plugin_data extends DokuWiki_Plugin {
                     }
 
                     $id = $this->_addPrePostFixes($column['type'], $id);
+
                     $outs[] = $R->internallink($id, $title, null, true);
                     break;
                 case 'nspage':

--- a/helper.php
+++ b/helper.php
@@ -235,6 +235,10 @@ class helper_plugin_data extends DokuWiki_Plugin {
                     $outs[] = $R->internallink($val, null, null, true);
                     break;
                 case 'title':
+                    list($id, $title) = explode('|', $val, 2);
+                    $id = $this->_addPrePostFixes($column['type'], $id);
+                    $outs[] = $R->internallink($id, $title, null, true);
+                    break;
                 case 'pageid':
                     list($id, $title) = explode('|', $val, 2);
 


### PR DESCRIPTION
This pull request replaces #163 

This pul request fixes multiple issues:
  * The title fields were not respecting the useHeading conf option
  * A value entered for page or data field may be linked as relative, but they are always looked-up absolute and hence should always be treated as such
  * This also fixes the issue that the ``%pageid%`` shown in ``datatable`` was occasionally wrong, when ``dataentry`` was in the root namespace, but ``datatable`` was not