### PR TITLE
only add pre- and suffix, if there is data

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -170,7 +170,11 @@ class helper_plugin_data extends DokuWiki_Plugin {
                 $post = $type['postfix'];
             }
         }
-        $val = $pre . $val . $post;
+		if($val != "")
+		{
+			$val = $pre . $val . $post;
+		}
+
         $val = $this->replacePlaceholders($val);
         return $val;
     }
@@ -311,7 +315,14 @@ class helper_plugin_data extends DokuWiki_Plugin {
 
                     //use ID from first value of the multivalued line
                     if($data == null) {
-                        $data = $ID;
+                        
+						//but only if is multivalued line
+						if($val!=$ID."|"){ 
+							$data = $ID;
+						}
+						else { //line is simply empty
+							$data = "";
+						}
                         $ID = $storedID;
                     } else {
                         $storedID = $ID;


### PR DESCRIPTION
Reason: I'm using a wiki based type with prefix = "[[person:" and sufffix="]]". With the last version by @Klap-in empty fields got converted to [[person:page_name_containing_the_dataentry]].

With this fix the are displayed empty. Am I missing something?


