### PR TITLE
Support for odt export in datatable and datalist

### DIFF
--- a/helper.php
+++ b/helper.php
@@ -220,7 +220,7 @@ class helper_plugin_data extends DokuWiki_Plugin {
      * @param Doku_Renderer_xhtml $R
      * @return string
      */
-    function _formatData($column, $value, Doku_Renderer_xhtml $R) {
+    function _formatData($column, $value, Doku_Renderer $R) {
         global $conf;
         $vals = explode("\n", $value);
         $outs = array();
@@ -274,16 +274,25 @@ class helper_plugin_data extends DokuWiki_Plugin {
                 case 'mail':
                     list($id, $title) = explode(' ', $val, 2);
                     $id = $this->_addPrePostFixes($column['type'], $id);
-                    $id = obfuscate(hsc($id));
+                    if($R->getFormat() == 'xhtml') // Don't obfuscate for ODT export
+                        $id = obfuscate(hsc($id));
                     if(!$title) {
                         $title = $id;
                     } else {
                         $title = hsc($title);
                     }
-                    if($conf['mailguard'] == 'visible') {
+                    if(($conf['mailguard'] == 'visible') && ($R->getFormat() == 'xhtml')) {
                         $id = rawurlencode($id);
                     }
-                    $outs[] = '<a href="mailto:' . $id . '" class="mail" title="' . $id . '">' . $title . '</a>';
+                    switch($R->getFormat())
+                    {
+                        case 'xhtml':
+                            $outs[] = '<a href="mailto:' . $id . '" class="mail" title="' . $id . '">' . $title . '</a>';
+                            break;
+                        case 'odt':
+                            $R->emaillink($id, $title);
+                            break;
+                    }
                     break;
                 case 'url':
                     $val = $this->_addPrePostFixes($column['type'], $val);

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -20,10 +20,54 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
         $this->Lexer->addSpecialPattern('----+ *datalist(?: [ a-zA-Z0-9_]*)?-+\n.*?\n----+', $mode, 'plugin_data_list');
     }
 
-    protected $before_item = '<li><div class="li">';
-    protected $after_item  = '</div></li>';
-    protected $before_val  = '';
-    protected $after_val   = ' ';
+    protected function before_item(Doku_Renderer $R)
+    {
+        switch($R->getFormat())
+        {
+            case 'xhtml':
+                $R->doc .= '<li><div class="li">';
+                break;
+            case 'odt':
+                $R->listitem_open();
+                $R->listcontent_open();
+                break;
+        }
+        return true;
+    }
+
+    protected function after_item(Doku_Renderer $R)
+    {
+        switch($R->getFormat())
+        {
+            case 'xhtml':
+                $R->doc .= '</div></li>';
+                break;
+            case 'odt':
+                $R->listcontent_close();
+                $R->listitem_close();
+                break;
+        }
+        return true;
+    }
+
+    protected function before_val($class, Doku_Renderer $R)
+    {
+        return true;
+    }
+
+    protected function after_val(Doku_Renderer $R)
+    {
+        switch($R->getFormat())
+        {
+            case 'xhtml':
+                $R->doc .= ' ';
+                break;
+            case 'odt':
+                $R->doc .= ' ';
+                break;
+        }
+        return true;
+    }
 
     /**
      * Before value in listitem
@@ -32,11 +76,11 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
      * @param int   $colno column number
      * @return string
      */
-    protected function beforeVal(&$data, $colno) {
+    protected function beforeVal(&$data, $colno, $class, Doku_Renderer $R) {
         if($data['sepbyheaders'] AND $colno === 0) {
-            return $data['headers'][$colno];
+            $R->doc .= $data['headers'][$colno];
         } else {
-            return $this->before_val;
+            $this->before_val($class, $R);
         }
     }
 
@@ -47,11 +91,11 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
      * @param int   $colno
      * @return string
      */
-    protected function afterVal(&$data, $colno) {
+    protected function afterVal(&$data, $colno, Doku_Renderer $R) {
         if($data['sepbyheaders']) {
-            return $data['headers'][$colno + 1];
+            $R->doc .= $data['headers'][$colno + 1];
         } else {
-            return $this->after_val;
+            $this->after_val($R);
         }
     }
 
@@ -62,8 +106,17 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
      * @param array $data  instruction by handler
      * @return string html of table header
      */
-    function preList($clist, $data) {
-        return '<div class="dataaggregation"><ul class="dataplugin_list ' . $data['classes'] . '">';
+    function preList($clist, $data, Doku_Renderer $R) {
+        switch($R->getFormat())
+        {
+            case 'xhtml':
+                $R->doc .= '<div class="dataaggregation"><ul class="dataplugin_list ' . $data['classes'] . '">';
+                break;
+            case 'odt':
+                $R->listu_open();
+                break;
+        }
+        return true;
     }
 
     /**
@@ -73,10 +126,20 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
      * @param array         $clist keys of the columns
      * @param Doku_Renderer $R
      */
-    function nullList($data, $clist, $R) {
-        $R->doc .= '<div class="dataaggregation"><p class="dataplugin_list ' . $data['classes'] . '">';
-        $R->cdata($this->getLang('none'));
-        $R->doc .= '</p></div>';
+    function nullList($data, $clist, Doku_Renderer $R) {
+        switch($R->getFormat())
+        {
+            case 'xhtml':
+                $R->doc .= '<div class="dataaggregation"><p class="dataplugin_list ' . $data['classes'] . '">';
+                $R->cdata($this->getLang('none'));
+                $R->doc .= '</p></div>';
+            break;
+            case 'odt':
+                $R->p_open();
+                $R->cdata($this->getLang('none'));
+                $R->p_close();
+            break;
+        }
     }
 
     /**
@@ -86,8 +149,17 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
      * @param int   $rowcnt number of rows
      * @return string html of table footer
      */
-    function postList($data, $rowcnt) {
-        return '</ul></div>';
+    function postList($data, $rowcnt, Doku_Renderer $R) {
+        switch($R->getFormat())
+        {
+            case 'xhtml':
+                $R->doc .= '</ul></div>';
+                break;
+            case 'odt':
+                $R->listu_close();
+                break;
+        }
+        return true;
     }
 
 }


### PR DESCRIPTION
We needed to export a big datatable to ODT and were quite surprised to find out that the data plugin currently doesn't support rendering to odt.
This PR adds basic support for datatable and datalist (untested). 

Before I continue fixing the remaining options in the helper's _formatData(), could somebody please comment on this?