### PR TITLE
Add alternate syntax <dataentry>

### DIFF
--- a/syntax/cloud.php
+++ b/syntax/cloud.php
@@ -53,6 +53,7 @@ class syntax_plugin_data_cloud extends syntax_plugin_data_table {
      */
     public function connectTo($mode) {
         $this->Lexer->addSpecialPattern('----+ *datacloud(?: [ a-zA-Z0-9_]*)?-+\n.*?\n----+', $mode, 'plugin_data_cloud');
+        $this->Lexer->addSpecialPattern('< *datacloud(?: [ a-zA-Z0-9_]*)?>\n.*?\n</ *datacloud *>', $mode, 'plugin_data_cloud');
     }
 
     /**

--- a/syntax/list.php
+++ b/syntax/list.php
@@ -18,6 +18,7 @@ class syntax_plugin_data_list extends syntax_plugin_data_table {
      */
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern('----+ *datalist(?: [ a-zA-Z0-9_]*)?-+\n.*?\n----+', $mode, 'plugin_data_list');
+        $this->Lexer->addSpecialPattern('< *datalist(?: [ a-zA-Z0-9_]*)?>\n.*?\n</ *datalist *>', $mode, 'plugin_data_list');
     }
 
     protected $before_item = '<li><div class="li">';

--- a/syntax/related.php
+++ b/syntax/related.php
@@ -18,6 +18,7 @@ class syntax_plugin_data_related extends syntax_plugin_data_table {
      */
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern('----+ *datarelated(?: [ a-zA-Z0-9_]*)?-+\n.*?\n----+', $mode, 'plugin_data_related');
+        $this->Lexer->addSpecialPattern('< *datarelated(?: [ a-zA-Z0-9_]*)?>\n.*?\n</ *datarelated *>', $mode, 'plugin_data_related');
     }
 
     /**

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -54,6 +54,7 @@ class syntax_plugin_data_table extends DokuWiki_Syntax_Plugin {
      */
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern('----+ *datatable(?: [ a-zA-Z0-9_]*)?-+\n.*?\n----+', $mode, 'plugin_data_table');
+        $this->Lexer->addSpecialPattern('< *datatable(?: [ a-zA-Z0-9_]*)?>\n.*?\n</ *datatable *>', $mode, 'plugin_data_table');
     }
 
     /**
@@ -75,8 +76,9 @@ class syntax_plugin_data_table extends DokuWiki_Syntax_Plugin {
         $lines = explode("\n", $match);
         array_pop($lines);
         $class = array_shift($lines);
-        $class = preg_replace('/^----+ *data[a-z]+/', '', $class);
-        $class = trim($class, '- ');
+        // Also remove <> from alternate syntax.
+        $class = preg_replace('/^(----+|<) *data[a-z]+/', '', $class);
+        $class = trim($class, '<- >');
 
         $data = array(
             'classes'       => $class,
@@ -309,7 +311,7 @@ class syntax_plugin_data_table extends DokuWiki_Syntax_Plugin {
                 $R->doc .= $this->afterVal($data, $num_rn);
 
                 // clean currency symbols
-                $nval = str_replace('$€₤', '', $cval);
+                $nval = str_replace('$â¬â¤', '', $cval);
                 $nval = str_replace('/ [A-Z]{0,3}$/', '', $nval);
                 $nval = str_replace(',', '.', $nval);
                 $nval = trim($nval);
@@ -499,7 +501,7 @@ class syntax_plugin_data_table extends DokuWiki_Syntax_Plugin {
             for($i = 0; $i < $len; $i++) {
                 $text .= '<td class="' . $data['align'][$i] . 'align">';
                 if(!empty($this->sums[$i])) {
-                    $text .= '∑ ' . $this->sums[$i];
+                    $text .= 'â ' . $this->sums[$i];
                 } else {
                     $text .= '&nbsp;';
                 }

--- a/syntax/taglist.php
+++ b/syntax/taglist.php
@@ -19,6 +19,7 @@ class syntax_plugin_data_taglist extends syntax_plugin_data_cloud {
      */
     function connectTo($mode) {
         $this->Lexer->addSpecialPattern('----+ *datataglist(?: [ a-zA-Z0-9_]*)?-+\n.*?\n----+', $mode, 'plugin_data_taglist');
+        $this->Lexer->addSpecialPattern('< *datataglist(?: [ a-zA-Z0-9_]*)?>\n.*?\n</ *datataglist *>', $mode, 'plugin_data_taglist');
     }
 
     protected $before_item = '<ul class="dataplugin_taglist %s">';


### PR DESCRIPTION
This branch adds an alternate syntax of type `<dataentry (classes)> ... </dataentry>` (same for all other syntax like datatable, etc.).
This syntax survives page edition in WYSIWYG editors, which replace chains of dashes (--, ---) by long dashes, and remove single line feeds.

In the case of dataentry, this branch also detects which syntax it should use when saving the edit form. It keeps the syntax type that is initially used on the page.