### PR TITLE
Numeric sorting and by multiple columns

### DIFF
--- a/_test/helper.test.php
+++ b/_test/helper.test.php
@@ -202,14 +202,15 @@ class helper_plugin_data_test extends DokuWikiTest {
         $this->assertEquals('en', $data['sql']);
     }
 
-    protected function createColumnEntry($name, $multi, $key, $origkey, $title, $type) {
+    protected function createColumnEntry($name, $multi, $key, $origkey, $title, $type, $datatype = '') {
         return array(
             'colname' => $name,
             'multi' => $multi,
             'key' => $key,
             'origkey' => $origkey,
             'title' => $title,
-            'type' => $type
+            'type' => $type,
+            'datatype' => $datatype
         );
     }
 

--- a/_test/syntax_plugin_data_entry.test.php
+++ b/_test/syntax_plugin_data_entry.test.php
@@ -318,14 +318,15 @@ class syntax_plugin_data_entry_test extends DokuWikiTest {
         $this->assertEquals($cols, $result['cols'], 'Cols array corrupted');
     }
 
-    protected function createColumnEntry($name, $multi, $key, $origkey, $title, $type) {
+    protected function createColumnEntry($name, $multi, $key, $origkey, $title, $type, $datatype = '') {
         return array(
             'colname' => $name,
             'multi' => $multi,
             'key' => $key,
             'origkey' => $origkey,
             'title' => $title,
-            'type' => $type
+            'type' => $type,
+            'datatype' => $datatype
         );
     }
 

--- a/_test/syntax_plugin_data_table.test.php
+++ b/_test/syntax_plugin_data_table.test.php
@@ -18,7 +18,7 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
             . 'headers : Details, "Assigned Employees \#no", stuff outside quotes """Deadline, ",  Personal website, $$$'."\n"
             . "max     : 10\n"
             . "filter  : type=web development\n"
-            . "sort    : ^volume\n"
+            . "sort    : ^(num)volume,%pageid%\n"
             . "dynfilters: 1\n"
             . "summarize : 1\n"
             . "align   : c\n"
@@ -112,7 +112,8 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
 
             ),
             'sort' => array(
-                'volume' => array('volume', 'DESC', '')
+                'volume' => array('volume', 'DESC', 'numeric'),
+                '%pageid%' => array('%pageid%', 'ASC', '')
             ),
             'align' => array(
                 '0' => 'center'
@@ -130,7 +131,7 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
                  LEFT JOIN data AS T1 ON T1.pid = W1.pid AND T1.key = 'employee' LEFT JOIN data AS T2 ON T2.pid = W1.pid AND T2.key = 'deadline' LEFT JOIN data AS T3 ON T3.pid = W1.pid AND T3.key = 'website' LEFT JOIN data AS T4 ON T4.pid = W1.pid AND T4.key = 'volume'
                 LEFT JOIN pages ON W1.pid=pages.pid
                 GROUP BY W1.pid
-                ORDER BY T4.value DESC LIMIT 11",
+                ORDER BY CAST(T4.value AS NUMERIC) DESC, pages.page ASC LIMIT 11",
             'cur_param' => array()
 
 );

--- a/_test/syntax_plugin_data_table.test.php
+++ b/_test/syntax_plugin_data_table.test.php
@@ -36,10 +36,10 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
         $data = array(
             'classes' => 'employees',
             'limit' => 10,
-            'dynfilters' => 1,
-            'summarize' => 1,
-            'rownumbers' => 1,
-            'sepbyheaders' => '',
+            'dynfilters' => true,
+            'summarize' => true,
+            'rownumbers' => true,
+            'sepbyheaders' => false,
             'headers' => array(
                 '0' => 'Details',
                 '1' => 'Assigned Employees #no',
@@ -71,6 +71,7 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
                     'origkey' => '%pageid%',
                     'title' => 'Title',
                     'type' => 'page',
+                    'datatype' => ''
                 ),
                 'employee' => array(
                     'colname' => 'employees',
@@ -78,7 +79,8 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
                     'key' => 'employee',
                     'origkey' => 'employee',
                     'title' => 'employee',
-                    'type' => ''
+                    'type' => '',
+                    'datatype' => ''
                 ),
                 'deadline' => array(
                     'colname' => 'deadline_dt',
@@ -86,7 +88,8 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
                     'key' => 'deadline',
                     'origkey' => 'deadline',
                     'title' => 'deadline',
-                    'type' => 'dt'
+                    'type' => 'dt',
+                    'datatype' => ''
                 ),
                 'website' => array(
                     'colname' => 'website_url',
@@ -94,7 +97,8 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
                     'key' => 'website',
                     'origkey' => 'website',
                     'title' => 'website',
-                    'type' => 'url'
+                    'type' => 'url',
+                    'datatype' => ''
                 ),
                 'volume' => array(
                     'colname' => 'volume',
@@ -102,13 +106,13 @@ class syntax_plugin_data_table_test extends DokuWikiTest {
                     'key' => 'volume',
                     'origkey' => 'volume',
                     'title' => 'volume',
-                    'type' => ''
+                    'type' => '',
+                    'datatype' => ''
                 ),
 
             ),
             'sort' => array(
-                '0' => 'volume',
-                '1' => 'DESC'
+                'volume' => array('volume', 'DESC', '')
             ),
             'align' => array(
                 '0' => 'center'

--- a/helper.php
+++ b/helper.php
@@ -369,15 +369,16 @@ class helper_plugin_data extends DokuWiki_Plugin {
      * @param string $col column name
      * @returns array with key, type, ismulti, title, opt
      */
-    function _column($col) {
-        preg_match('/^([^_]*)(?:_(.*))?((?<!s)|s)$/', $col, $matches);
+    function _column($col){
+        preg_match('/^([^_]*)(\(num\))?(?:_(.*))?((?<!s)|s)$/', $col, $matches);
         $column = array(
             'colname' => $col,
-            'multi'   => ($matches[3] === 's'),
+            'multi'   => ($matches[4] === 's'),
             'key'     => utf8_strtolower($matches[1]),
             'origkey' => $matches[1], //similar to key, but stores upper case
             'title'   => $matches[1],
-            'type'    => utf8_strtolower($matches[2])
+            'type'    => utf8_strtolower($matches[3]),
+            'datatype'=> $matches[2] == '(num)' ? 'numeric' : ''
         );
 
         // fix title for special columns

--- a/syntax/table.php
+++ b/syntax/table.php
@@ -632,7 +632,7 @@ class syntax_plugin_data_table extends DokuWiki_Syntax_Plugin {
                         $from .= ' AND ' . $tables[$col] . ".key = " . $sqlite->quote_string($col);
                     }
 
-                    $sortcolumn = $tables[$col] . '.value ';
+                    $sortcolumn = $tables[$col] . '.value';
                 }
                 if($type == 'numeric') {
                     $sortcolumn = 'CAST(' . $sortcolumn . ' AS NUMERIC)';


### PR DESCRIPTION
Most functionality was in `sortnumerically` branch already, I have just fixed merge conflicts and added tests.

The usage is as follows:

```
sort    : ^(num)volume,^name
```

- multiple columns are comma separated
- columns prefixed with `(num)` will be cast as integer

Refs: #78, #108, #175.